### PR TITLE
improve frontend-design skill description + structure

### DIFF
--- a/ai-tooling/skills/frontend-design/SKILL.md
+++ b/ai-tooling/skills/frontend-design/SKILL.md
@@ -14,16 +14,16 @@ allowed-tools: "Read, Grep, Glob, Bash, Write, Edit"
 
 Build frontend interfaces that reject generic aesthetics. Output complete, runnable code with intentional typography, color, layout, and motion.
 
-## Step 1 -- Gather Context
+## Step 1 - Gather Context
 
 Collect before writing any code:
 
-1. **Purpose** -- Problem being solved and target user.
-2. **Aesthetic direction** -- Commit to one: brutalist, editorial, retro-futuristic, luxury, playful, or utilitarian. If unspecified, propose one with rationale.
-3. **Constraints** -- Framework, browser support, WCAG level, brand rules.
-4. **Differentiator** -- The single visual idea that makes this memorable.
+1. **Purpose** - Problem being solved and target user.
+2. **Aesthetic direction** - Commit to one: brutalist, editorial, retro-futuristic, luxury, playful, or utilitarian. If unspecified, propose one with rationale.
+3. **Constraints** - Framework, browser support, WCAG level, brand rules.
+4. **Differentiator** - The single visual idea that makes this memorable.
 
-## Step 2 -- Define Design Tokens
+## Step 2 - Define Design Tokens
 
 Set up tokens before component code. Starter template:
 
@@ -55,21 +55,21 @@ Set up tokens before component code. Starter template:
 
 Replace values to match the chosen aesthetic. Every color, font, and spacing value must reference tokens.
 
-## Step 3 -- Build
+## Step 3 - Build
 
 Implementation rules:
 
-- **Layout** -- Break the grid intentionally. Use asymmetry, overlap, or unexpected composition. Never default to centered cards on white.
-- **Motion** -- Two to three high-impact moments: page-load entrance, staggered reveals, hover micro-interactions. Prefer CSS `@keyframes` and `transition` over JS.
-- **Backgrounds** -- Add depth with gradients, textures, or geometric shapes.
-- **Responsiveness** -- Mobile-first. Verify at 375px, 768px, 1280px.
-- **Accessibility** -- WCAG AA contrast ratios. Keyboard-navigable interactive elements. Semantic HTML throughout.
+- **Layout** - Break the grid intentionally. Use asymmetry, overlap, or unexpected composition. Never default to centered cards on white.
+- **Motion** - Two to three high-impact moments: page-load entrance, staggered reveals, hover micro-interactions. Prefer CSS `@keyframes` and `transition` over JS.
+- **Backgrounds** - Add depth with gradients, textures, or geometric shapes.
+- **Responsiveness** - Mobile-first. Verify at 375px, 768px, 1280px.
+- **Accessibility** - WCAG AA contrast ratios. Keyboard-navigable interactive elements. Semantic HTML throughout.
 
-## Step 4 -- Deliver
+## Step 4 - Deliver
 
 Every response includes:
 
-1. Complete, runnable code -- no pseudocode or placeholders.
+1. Complete, runnable code - no pseudocode or placeholders.
 2. One to two sentences on aesthetic direction and key decisions.
 3. Font CDN links or asset references required to render.
 

--- a/ai-tooling/skills/frontend-design/SKILL.md
+++ b/ai-tooling/skills/frontend-design/SKILL.md
@@ -1,52 +1,86 @@
 ---
 name: frontend-design
-description: Create distinctive, production-grade frontend interfaces with high design quality. Use when users ask to build web components, pages, or applications.
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+description: >-
+  Implement responsive layouts, style components with CSS custom properties, build
+  interactive forms, and structure semantic HTML for production-grade frontend interfaces.
+  Use when building web components, landing pages, dashboards, UI layouts, or web applications.
+  Trigger on: "build a page", "design a component", "create a UI", "frontend",
+  "landing page", "web interface", "dashboard layout", "styled component", "hero section".
+  Not for backend APIs, data fetching logic, or framework-specific state management.
+allowed-tools: "Read, Grep, Glob, Bash, Write, Edit"
 ---
 
 # Frontend Design Skill
 
-This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic aesthetics. Implement real working code with exceptional attention to typography, layout, motion, and atmosphere.
+Build frontend interfaces that reject generic aesthetics. Output complete, runnable code with intentional typography, color, layout, and motion.
 
-## Design Thinking
+## Step 1 -- Gather Context
 
-Before coding, understand the context and commit to a bold aesthetic direction:
+Collect before writing any code:
 
-- **Purpose**: What problem does this interface solve? Who uses it?
-- **Tone**: Pick a strong direction (brutalist, editorial, retro-futuristic, luxury, playful, utilitarian). Commit fully.
-- **Constraints**: Framework, performance, accessibility, brand rules.
-- **Differentiation**: Identify the one unforgettable visual idea.
+1. **Purpose** -- Problem being solved and target user.
+2. **Aesthetic direction** -- Commit to one: brutalist, editorial, retro-futuristic, luxury, playful, or utilitarian. If unspecified, propose one with rationale.
+3. **Constraints** -- Framework, browser support, WCAG level, brand rules.
+4. **Differentiator** -- The single visual idea that makes this memorable.
 
-## Execution Guidelines
+## Step 2 -- Define Design Tokens
 
-- **Typography**: Use distinctive fonts. Avoid generic system stacks (Inter, Roboto, Arial). Pair display and body type.
-- **Color**: Define CSS variables. Choose dominant colors with sharp accents. Avoid default purple gradients on white.
-- **Motion**: Favor a few high-impact moments (page-load, staggered reveals). Use CSS animations when possible.
-- **Layout**: Break the grid when appropriate. Use asymmetry, overlap, or unexpected composition.
-- **Backgrounds**: Add depth with gradients, texture, or shapes. Avoid flat, empty backgrounds.
+Set up tokens before component code. Starter template:
 
-## Output Requirements
+```css
+:root {
+  /* Typography */
+  --font-display: 'Space Grotesk', sans-serif;
+  --font-body: 'IBM Plex Sans', sans-serif;
 
-Provide working code that is:
+  /* Color */
+  --color-primary: #1a1a2e;
+  --color-accent: #e94560;
+  --color-surface: #f5f5f0;
+  --color-text: #16213e;
 
-- Production-grade and functional
-- Visually striking and cohesive
-- Explicit about the aesthetic direction
-- Matched in complexity to the design intent
+  /* Spacing (4px base) */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 2rem;
+  --space-xl: 4rem;
 
-## Response Checklist
-
-```markdown
-Frontend Design Checklist
-
-- [ ] Clarify purpose, audience, and constraints
-- [ ] Declare a specific aesthetic direction
-- [ ] Define typography and color system
-- [ ] Design layout and motion moments
-- [ ] Implement production-grade code
-- [ ] Explain key visual decisions briefly
+  /* Motion */
+  --duration-fast: 150ms;
+  --duration-normal: 300ms;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+}
 ```
+
+Replace values to match the chosen aesthetic. Every color, font, and spacing value must reference tokens.
+
+## Step 3 -- Build
+
+Implementation rules:
+
+- **Layout** -- Break the grid intentionally. Use asymmetry, overlap, or unexpected composition. Never default to centered cards on white.
+- **Motion** -- Two to three high-impact moments: page-load entrance, staggered reveals, hover micro-interactions. Prefer CSS `@keyframes` and `transition` over JS.
+- **Backgrounds** -- Add depth with gradients, textures, or geometric shapes.
+- **Responsiveness** -- Mobile-first. Verify at 375px, 768px, 1280px.
+- **Accessibility** -- WCAG AA contrast ratios. Keyboard-navigable interactive elements. Semantic HTML throughout.
+
+## Step 4 -- Deliver
+
+Every response includes:
+
+1. Complete, runnable code -- no pseudocode or placeholders.
+2. One to two sentences on aesthetic direction and key decisions.
+3. Font CDN links or asset references required to render.
+
+## Checklist
+
+Verify before finalizing:
+
+- [ ] Aesthetic direction declared and consistently applied
+- [ ] All visual values use CSS custom properties
+- [ ] Layout avoids generic patterns (centered cards, purple gradients)
+- [ ] Two or more CSS motion moments implemented
+- [ ] Responsive across 375px, 768px, 1280px breakpoints
+- [ ] WCAG AA met
+- [ ] Decisions briefly explained


### PR DESCRIPTION
hey @nicholasgriffintn, thanks for publishing your machine-setup repo. really like how you've built out a full ai-tooling suite with `12` skills, agents, hooks, and commands all in one place. I've just starred it.

was running your skills through some evals and noticed a few things on frontend-design that were pretty quick to improve (moving from `~18%` to `~96%` agent performance):

- fixed `allowed-tools` frontmatter from YAML list to string format, which was blocking the skill from passing validation entirely

- expanded description with specific capabilities like _implement responsive layouts, style components with CSS custom properties, build interactive forms_ + trigger terms + exclusion clause

- added a concrete CSS design tokens starter template + tightened the `4`-step workflow with explicit implementation rules for layout, motion, responsiveness + accessibility

these were easy changes to bring the skill in line with what performs well against **Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make.

if you want to review your other skills, two options: I can open a follow-up PR with a GitHub Action that auto-scores skill.md changes on every PR (no signup, no token needed — [here's exactly what it does](https://github.com/tessl-io/skill-eval-action)). or if you'd rather do it yourself, spin up Claude Code and run `tessl skill review`.

happy to answer any questions on the changes.